### PR TITLE
Increase amount of dirt being generated

### DIFF
--- a/dwarfs/code/modules/mapgen/mapgen.dm
+++ b/dwarfs/code/modules/mapgen/mapgen.dm
@@ -18,10 +18,10 @@ GLOBAL_VAR_INIT(temperature_seed, 0)
 		switch(height)
 			if(-INFINITY to -0.7)
 				turf_type = /turf/open/water
-			if(-0.7 to -0.6)
+			if(-0.7 to -0.45)
 				turf_type = /turf/open/floor/dirt
 				generate_turf_flora(T, 8)
-			if(-0.6 to -0.3)
+			if(-0.45 to -0.3)
 				if(temp > 0)
 					turf_type = /turf/open/floor/sand
 				else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Slightly increases the change for generated turf to be a dirt tile by giving it a larger margin in the heat generation thingy

number suggestions are nice

![gif1](https://cdn.discordapp.com/attachments/945051043937542196/1041030708250025995/dirty.gif)

![gif2](https://cdn.discordapp.com/attachments/945051043937542196/1041031037800689664/dirty2.gif)

## Why It's Good For The Game

having more dirt outside of the initial colonly will promote spreading out more. also pots need 5 dirt and I dont want to have to uproot the spawn area's dirt

## Changelog
:cl:
tweak: tweaked a few things
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
