### PR TITLE
Fix being able to dig at lowest Z level

### DIFF
--- a/code/game/turfs/open/floor.dm
+++ b/code/game/turfs/open/floor.dm
@@ -49,6 +49,16 @@
 /turf/open/floor/proc/setup_burnt_states()
 	return
 
+/turf/open/floor/proc/try_digdown(obj/item/I,mob/user)
+	var/turf/TD = SSmapping.get_turf_below(src)
+	if(ismineralturf(TD) || isopenturf(TD))
+		if(ismineralturf(TD))
+			TD.ScrapeAway()
+		ChangeTurf(/turf/open/openspace)
+		user.visible_message(span_notice("[user] digs out a hole in the ground."), span_notice("You dig out a hole in the ground."))
+	else
+		to_chat(user, span_warning("Something very dense underneath!"))
+
 /turf/open/floor/Destroy()
 	if(is_fortress_level(z))
 		GLOB.station_turfs -= src

--- a/dwarfs/code/turfs/open.dm
+++ b/dwarfs/code/turfs/open.dm
@@ -45,15 +45,7 @@
 			if(QDELETED(src))
 				return
 			if(digged_up)
-				var/turf/TD = SSmapping.get_turf_below(src)
-				if(ismineralturf(TD) || isopenturf(TD))
-					if(ismineralturf(TD))
-						TD.ScrapeAway()
-					ChangeTurf(/turf/open/openspace)
-					user.visible_message(span_warning("<b>[user]</b> digs up a hole!") , \
-										span_notice("You dig up a hole."))
-				else
-					to_chat(user, span_warning("Something very dense underneath!"))
+				try_digdown(I,user)
 			else
 				for(var/i in 1 to rand(2, 5))
 					var/obj/item/S = new /obj/item/stack/ore/stone(src)
@@ -93,8 +85,7 @@
 			if(QDELETED(src))
 				return
 			if(digged_up)
-				user.visible_message(span_notice("[user] digs out a hole in the ground."), span_notice("You dig out a hole in the ground."))
-				ChangeTurf(/turf/open/openspace)
+				try_digdown(xI,user)
 			else
 				new/obj/item/stack/ore/smeltable/sand(src, rand(3,6))
 				digged_up = TRUE
@@ -129,8 +120,7 @@
 		var/dig_time = I.tool_behaviour == TOOL_SHOVEL ? 5 SECONDS : 10 SECONDS
 		if(I.use_tool(src, user, dig_time))
 			if(digged_up)
-				user.visible_message(span_notice("[user] digs out a hole in the ground."), span_notice("You dig out a hole in the ground."))
-				ChangeTurf(/turf/open/openspace)
+				try_digdown(I,user)
 			else
 				new/obj/item/stack/dirt(src, rand(2,5))
 				user.visible_message(span_notice("<b>[user]</b> digs up some dirt.") , \

--- a/dwarfs/code/turfs/open.dm
+++ b/dwarfs/code/turfs/open.dm
@@ -85,7 +85,7 @@
 			if(QDELETED(src))
 				return
 			if(digged_up)
-				try_digdown(xI,user)
+				try_digdown(I,user)
 			else
 				new/obj/item/stack/ore/smeltable/sand(src, rand(3,6))
 				digged_up = TRUE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So stone correctly implemented this, but the other turfs did not. Decided to refactor the code to avoid future headaches

## Why It's Good For The Game

no ugly black hole

## Changelog
:cl:
fix: you cannot dig into the void
refactor: call try_digdown() if you want to dig to a tile below
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
