### PR TITLE
loadout fix and a new debug outfit

### DIFF
--- a/code/__HELPERS/icons.dm
+++ b/code/__HELPERS/icons.dm
@@ -1051,7 +1051,7 @@ GLOBAL_LIST_EMPTY(friendly_animal_types)
 
 		if(prefs)
 			prefs.copy_to(body,TRUE,FALSE)
-		else if (outfit_override)
+		if (outfit_override)
 			body.equipOutfit(outfit_override,visualsOnly = TRUE)
 
 

--- a/code/modules/admin/verbs/selectequipment.dm
+++ b/code/modules/admin/verbs/selectequipment.dm
@@ -132,8 +132,8 @@
 	if(!cached_outfits)
 		cached_outfits = list()
 		cached_outfits += list(outfit_entry("Main", /datum/outfit, "Naked", priority=TRUE))
-		cached_outfits += make_outfit_entries("Main", subtypesof(/datum/outfit))
-
+		cached_outfits += list(outfit_entry("Main", /datum/outfit/dwarf/debug, "Debug", priority=TRUE))
+		cached_outfits += make_outfit_entries("Main", subtypesof(/datum/outfit) - /datum/outfit/dwarf/debug)
 	data["outfits"] = cached_outfits
 	return data
 

--- a/dwarfs/code/unsorted/debugdwarf.dm
+++ b/dwarfs/code/unsorted/debugdwarf.dm
@@ -1,0 +1,48 @@
+/datum/outfit/dwarf/debug
+	name = "Dwarf debug"
+	back = /obj/item/storage/satchel/debug/filled
+
+
+/datum/outfit/dwarf/debug/post_equip(mob/living/carbon/human/H, visualsOnly)
+	. = ..()
+	H.mind.set_experience(/datum/skill/mining,SKILL_EXP_LEGEND)
+	H.mind.set_experience(/datum/skill/martial,SKILL_EXP_LEGEND)
+	H.mind.set_experience(/datum/skill/logging,SKILL_EXP_LEGEND)
+	H.mind.set_experience(/datum/skill/farming,SKILL_EXP_LEGEND)
+	H.mind.set_experience(/datum/skill/butchering,SKILL_EXP_LEGEND)
+	H.mind.set_experience(/datum/skill/cooking,SKILL_EXP_LEGEND)
+	H.mind.set_experience(/datum/skill/combat,SKILL_EXP_LEGEND)
+	H.mind.set_experience(/datum/skill/skinning,SKILL_EXP_LEGEND)
+	H.mind.set_experience(/datum/skill/smithing,SKILL_EXP_LEGEND)
+
+/obj/item/storage/satchel/debug
+	name = "Satchel of holding"
+
+/obj/item/storage/satchel/debug/filled
+
+/obj/item/storage/satchel/debug/filled/PopulateContents()
+	. = ..()
+	new /obj/item/pickaxe(src)
+	new /obj/item/shovel(src)
+	new /obj/item/builder_hammer(src)
+	new /obj/item/smithing_hammer(src)
+	new /obj/item/trowel(src)
+	new /obj/item/tongs(src)
+	new /obj/item/hoe(src)
+	new /obj/item/axe(src)
+	new /obj/item/stack/sheet/stone/fifty(src)
+	new /obj/item/stack/sheet/planks/fifty(src)
+
+
+/obj/item/storage/backpack/debug/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_combined_w_class = INFINITY
+	STR.max_w_class = WEIGHT_CLASS_HUGE
+	STR.max_items = INFINITY
+
+/obj/item/stack/sheet/stone/fifty
+	amount = 50
+
+/obj/item/stack/sheet/planks/fifty
+	amount = 50

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1228,6 +1228,7 @@
 #include "dwarfs\code\structures\tables.dm"
 #include "dwarfs\code\turfs\closed.dm"
 #include "dwarfs\code\turfs\open.dm"
+#include "dwarfs\code\unsorted\debugdwarf.dm"
 #include "dwarfs\code\unsorted\dwarf.dm"
 #include "dwarfs\code\unsorted\goblin.dm"
 #include "dwarfs\code\unsorted\recipes.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the dummy for loadouts didnt render properly if you switched between outfits, should help fix

also new debug outfit skilled in everything

## Why It's Good For The Game

im to lazy to spawn tools and skill skills via VV and too impatiant to just wait for lvl 0 action

## Changelog
:cl:
add: Debug outfit
fix: select equipment potrait now updates based on the outfit selected as preview
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
