### PR TITLE
Remove Vinegar

### DIFF
--- a/dwarfs/code/modules/brewing/reagents/wines.dm
+++ b/dwarfs/code/modules/brewing/reagents/wines.dm
@@ -3,9 +3,10 @@
 	description = "Traditional dwarfen mushroom wine. Heals dwarf's souls and minds (and probably more)."
 	color = "#c9220cff"
 
-/datum/reagent/consumable/ethanol/wine/New()
-	. = ..()
-	AddComponent(/datum/component/fermentable, ferment_into=/datum/reagent/consumable/vinegar)
+//datum/reagent/consumable/ethanol/wine/New()
+//	. = ..()
+//	AddComponent(/datum/component/fermentable, ferment_into=/datum/reagent/consumable/vinegar)
+// TEMPORARILY REMOVED VINEGAR - It has no current use - Art
 
 /datum/reagent/consumable/ethanol/wine/plump
 	name = "Plump Wine"


### PR DESCRIPTION
Temporarily remove VINEGAR as it currently has no use and only serves to spoil wine left in a demijohn too long.